### PR TITLE
[afxtask] x64 上でタスクをファイル窓に表示できなかったのを修正

### DIFF
--- a/afxcom/afxwapi.h
+++ b/afxcom/afxwapi.h
@@ -27,7 +27,7 @@
 #define APISUCCESS(ret)				(ret == 1)
 #define APIFAILE(ret)				(ret == 0)
 
-#pragma pack(1)
+#pragma pack(push, 1)
 
 typedef HGLOBAL HAFX;
 
@@ -263,6 +263,6 @@ int  WINAPI ApiRemoveDirectory(HAFX handle, LPCWSTR szItemPath);
  */
 int  WINAPI ApiShowContextMenu(HAFX handle, const HWND hWnd, DWORD x, DWORD y, LPCWSTR szItemPath);
 
-
+#pragma pack(pop)
 #endif	/* __AFXWAPI__ */
 


### PR DESCRIPTION
## 問題

x64 上だと、afxtask でタスクをファイル窓に表示できない。
## 修正内容

構造体のパッキング指定を、afxwapi.h 内でのみ有効になるように修正しました。

何故、このような修正になったのかを以下で記載します。(少しややこしいです)
## ざっくりとした原因

そもそも x64 上で動かなかった原因は、
Process32First、Process32Next が失敗していたためです。
そのさい、GetLastError は 24(ERROR_BAD_LENGTH) を返していました。

これは、afxwapi.h 内の #pragma pack(1) の影響で
構造体のサイズが変わったため発生していました。
## 少し具体的に

具体的に書いていきます。
afxtask.cpp は以下の順でヘッダファイルを読みこんでいます。

```
#include "afxwapi.h"  ← ここで #pragma pack(1)
...
#include <tlhelp32.h>  ← ここで PROCESSENTRY32 構造体が定義
...
```

なので、PROCESSENTRY32 構造体は pack(1) として構造体がパッキングされます。
その結果、PROCESSENTRY32 構造体のサイズが通常時とは変わってしまいます。

構造体のサイズが変わってしまったので、
その構造体を使用する Process32First、Process32Next を呼び出したとき
エラー 24(ERROR_BAD_LENGTH) が発生していました。

これを解決するため、afxwapi.h 内でのみ、pack(1) 指定が有効になるよう修正しました。
## 別の解決法

afxtask.cpp 内でヘッダファイルの読みこみ順序を変えるという別の解決法もあるのですが、
今後また似たようなバグが発生しかねないので、今回の修正方法を採用しました。

別の解決法(ヘッダファイルの読みこみ順序を変える)

```
#include <tlhelp32.h>  ← ここで PROCESSENTRY32 構造体が定義
#include "afxwapi.h"  ← ここで #pragma pack(1)
```
