### PR TITLE
[afxtask]  表示されるプロセスの作成時刻をローカル時刻に修正

### DIFF
--- a/afxtask/afxtask.cpp
+++ b/afxtask/afxtask.cpp
@@ -201,12 +201,14 @@ int _pid2item(PROCESSENTRY32* entry, lpApiItemInfo lpItemInfo)
 	FILETIME exitTime;//プロセスの終了時刻
 	FILETIME kernelTime;//カーネルモードでのプロセス動作時間
 	FILETIME userTime;//ユーザーモードでのプロセス動作時間
+	FILETIME localCreationTime;//プロセスの作成時刻(ローカル時刻)
 	GetProcessTimes(hProc, 
 		&creationTime, 
 		&exitTime, 
 		&kernelTime, 
 		&userTime);
-	lpItemInfo->ullTimestamp = creationTime;
+	FileTimeToLocalFileTime(&creationTime, &localCreationTime);
+	lpItemInfo->ullTimestamp = localCreationTime;
 
 	// ここで閉じる
 	CloseHandle( hProc );


### PR DESCRIPTION
表示するプロセスの作成時刻が、世界協定時刻だったのをローカル時刻に修正しました。

あと、ここで質問すべきものか分からないのですが、一つ伺いたいことがあります。
yuratomo さんの afxcom.cpp 等を流用してあふw のプラグインを作りたい場合、
ライセンスはどうなりますか？
afxbkmk など一部ツールには記載があるのですが、
ツール共通で使用しているソース(afxcom.cpp/h)等には記載が見当たらないので質問させていただきました。
