### PR TITLE
[afxfazzy] 末尾のコマンド欠けを修正

### DIFF
--- a/afxfazzy/afxfazzy.cpp
+++ b/afxfazzy/afxfazzy.cpp
@@ -576,7 +576,7 @@ void LoadMenus(HWND hDlg, HWND hList, int start, int cnt, WCHAR** av)
 						swprintf(buf,  L"&CD %s", path2);
 						FormatLine(title, path2, buf, line);
 						SendMessage(hList, EM_REPLACESEL, 0, (LPARAM)line);
-						len += wcslen(line);
+						len += wcslen(line) + 1;
 					}
 				}
 				AfxCleanup(pAfxApp);
@@ -594,7 +594,7 @@ void LoadMenus(HWND hDlg, HWND hList, int start, int cnt, WCHAR** av)
 					swprintf(buf,  L"&CD %s", path2);
 					FormatLine(title, buf, buf, line);
 					SendMessage(hList, EM_REPLACESEL, 0, (LPARAM)line);
-					len += wcslen(line);
+					len += wcslen(line) + 1;
 				}
 			}
 		} else {
@@ -627,7 +627,7 @@ void LoadMenus(HWND hDlg, HWND hList, int start, int cnt, WCHAR** av)
 					d3[wcslen(d3)-1] = L'\0';
 					FormatLine(title, name, d3, line);
 					SendMessage(hList, EM_REPLACESEL, 0, (LPARAM)line);
-					len += wcslen(line);
+					len += wcslen(line) + 1;
 				}
 			}
 			fclose(fp);
@@ -995,8 +995,6 @@ void DoMask(HWND hWnd, HWND hWndList)
 	for (std::vector<std::wregex *>::iterator it = regex.begin(); it != regex.end(); it++) {
 		delete *it;
 	}
-	_work_len = wcslen(_work);
-	SendMessage(hWndList, WM_SETTEXT,    0, (LPARAM)_work);
 	RemoveLastLineFeed(hWndList);
 	_work_len = wcslen(_work);
 


### PR DESCRIPTION
すみません、自分の修正(#3)の修正です。
以下 2 点です。
-   末尾のコマンドが欠けていたのを修正
-   2重上書きしていた無駄な処理(_work_len と SendMessageの箇所)を削除

前者は、末尾のコマンドが、本来は、

```
"!!reload      (メニューをリロード)" !!reload
```

こうなるべきが、以下のように一部欠けてしまっていました。

```
"!!reload      (メニューをリロード)" !!rel
```
